### PR TITLE
fix: dockerfile was not caching correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,18 @@ RUN apk add --no-cache musl-dev=1.2.2-r1 openssl-dev=1.1.1l-r0 libsodium-dev=1.0
 
 # Create build directory as root
 WORKDIR /usr/src
-RUN USER=root cargo new service
+RUN USER=root cargo new redact-store
 
 # Perform an initial compilation to cache dependencies
-WORKDIR /usr/src/service
+WORKDIR /usr/src/redact-store
 COPY Cargo.lock Cargo.toml ./
 RUN echo "fn main() {println!(\"if you see this, the image build failed and kept the depency-caching entrypoint. check your dockerfile and image build logs.\")}" > src/main.rs
 RUN cargo build --release --locked
 
 # Load source code to create final binary
 RUN rm -rf src
-RUN rm -rf target/release/deps/service*
+RUN rm -rf target/release/deps/redact_store*
+RUN rm -rf target/release/redact-store*
 COPY src src
 RUN cargo build --release --locked
 
@@ -33,6 +34,6 @@ USER notroot:notroot
 
 # Copy binary files
 WORKDIR /usr/local/bin
-COPY --from=builder /usr/src/service/target/release/redact-store service
+COPY --from=builder /usr/src/redact-store/target/release/redact-store service
 
 ENTRYPOINT ["service"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -18,7 +18,8 @@ RUN cargo build --release --locked
 
 # Load source code to create final binary
 RUN rm -rf src
-RUN rm -rf target/release/deps/service
+RUN rm -rf target/release/deps/redact_store*
+RUN rm -rf target/release/redact-store*
 COPY src src
 RUN cargo build --release --locked
 
@@ -38,6 +39,6 @@ FROM alpine:3.13
 
 # Copy binary files
 WORKDIR /usr/local/bin
-COPY --from=builder /usr/src/service/target/release/redact-store service
+COPY --from=builder /usr/src/service/target/release/redact-store redact-store
 
-ENTRYPOINT ["service"]
+ENTRYPOINT ["redact-store"]


### PR DESCRIPTION
- Dockerfiles were deleting target/release/deps/redact-store
- They need to delete target/release/deps/redact_store* and
  target/release/redact-store*
- If both the root and deps redact-store entries are not deleted,
  the deps binary is copied on build, not using the new /src